### PR TITLE
docs: Fix a few typos

### DIFF
--- a/selfpipe.py
+++ b/selfpipe.py
@@ -24,7 +24,7 @@
 
 """
 Demonstrates SELF-PIPE Trick that is used to
-avoid race condtions when waiting for signals and calling select() on
+avoid race conditions when waiting for signals and calling select() on
 a set of descriptors.
 """
 
@@ -76,7 +76,7 @@ def main():
     # the call to 'select' - but we're ready for it, bring it on!
 
     # call 'select' in loop - this way we determine the signal arrival
-    # through examinination of the read end of the pipe (RD descriptor)
+    # through examination of the read end of the pipe (RD descriptor)
     while True:
         try:
             readables, writables, exceptions = select.select(

--- a/server04.py
+++ b/server04.py
@@ -85,7 +85,7 @@ def child_loop(index, parent_pipe):
         # block waiting for a descriptor from the parent
         fd = read_fd(parent_pipe)
 
-        # create a socket object from the desriptor passed by the parent.
+        # create a socket object from the descriptor passed by the parent.
         # this socket represents connection to a client
         conn = socket.fromfd(fd, socket.AF_INET, socket.SOCK_STREAM)
 


### PR DESCRIPTION
There are small typos in:
- selfpipe.py
- server04.py

Fixes:
- Should read `examination` rather than `examinination`.
- Should read `descriptor` rather than `desriptor`.
- Should read `conditions` rather than `condtions`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md